### PR TITLE
java: add class and date tools to enable juicy Velocity vulnerabilities [issue 4]

### DIFF
--- a/java/spring/pom.xml
+++ b/java/spring/pom.xml
@@ -46,6 +46,12 @@
 			<artifactId>spring-velocity-support</artifactId>
 			<version>2.3</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.velocity.tools</groupId>
+			<artifactId>velocity-tools-generic</artifactId>
+			<version>3.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/java/spring/src/main/java/com/example/demo/HelloController.java
+++ b/java/spring/src/main/java/com/example/demo/HelloController.java
@@ -13,6 +13,8 @@ import org.apache.velocity.runtime.resource.util.StringResourceRepository;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.app.Velocity;
 import org.apache.velocity.VelocityContext;
+import org.apache.velocity.tools.generic.ClassTool;
+import org.apache.velocity.tools.generic.DateTool;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -95,6 +97,8 @@ public class HelloController {
 
       VelocityContext context = new VelocityContext();
       context.put("name", "World");
+      context.put("class", new ClassTool());
+      context.put("date", new DateTool());
 
       org.apache.velocity.Template template = engine.getTemplate("newTemplate");
       StringWriter writer = new StringWriter();


### PR DESCRIPTION
Makes template-injection-playground/java vulnerable to more SSTI attacks.

Written using aider (an AI coding tool) as follows:
1. told aider to create a commandline-only demo of Velocity that took a template on stdin and wrote its expansion to stdout
2. iterated until that could handle $date and $class
3. backported the interesting bits to template-injection-playground

Addresses https://github.com/Hackmanit/template-injection-playground/issues/4

Given that I'm not a Java developer anymore, this deserves a bit more review than a non-vibe-coded change, but it does look nicely minimal.